### PR TITLE
bm: fix help() error message

### DIFF
--- a/bm
+++ b/bm
@@ -12,7 +12,7 @@ DMENULINES=15
 help () {
     echo "Call without an argument to be prompted with dmenu."
     echo "Flags:"
-    printf "-h, --help\n-c, --copy\n-a, --add\n-e, --edit\n"
+    echo '-h, --help\n-c, --copy\n-a, --add\n-e, --edit'
 }
 
 copy () {


### PR DESCRIPTION
printf(1) ouputs "printf: Illegal option -h". Thus, replace it with echo(1) to avoid such inconveniences. 